### PR TITLE
Feature/method 5

### DIFF
--- a/Swiftlogistics-esb/README.md
+++ b/Swiftlogistics-esb/README.md
@@ -1,31 +1,59 @@
 # SwiftLogistics ESB Starter
+
 This project is a Spring Boot + Apache Camel ESB prototype that integrates with the Python mock services:
+
 - CMS (SOAP) at http://localhost:5001
 - ROS (REST) at http://localhost:5002
 - WMS (TCP) at port 5003
 
 Build:
-  mvn clean package
+mvn clean package
 
 Run:
-  java -jar target/esb-starter-0.0.1-SNAPSHOT.jar
+java -jar target/esb-starter-0.0.1-SNAPSHOT.jar
 
 Or with Docker compose:
-  docker-compose up --build
+docker-compose up --build
 
 Theesh Testing using curl
-Method 3 : 
+Method 3 :
 curl -X GET "http://localhost:8084/orders/ORD001/status" \
-     -H "Content-Type: application/json"
+ -H "Content-Type: application/json"
 
-output : 
+output :
 {"orderId":"ORD001","cmsStatus":"processing","routeStatus":"route_not_found","packageStatus":"in_warehouse","timestamp":1757702152846}
 
 Method 4 :
+
 # Test the update endpoint
+
 curl -X PUT "http://localhost:8084/orders/ORD001/status?status=shipped" \
-     -H "Content-Type: application/json"
+ -H "Content-Type: application/json"
 
 output :
 {"rosUpdate":"ROS route for order ORD001 updated to shipped successfully","newStatus":"shipped","orderId":"ORD001","success":true,"wmsUpdate":"Unknown package update response type: 8","cmsUpdate":"CMS order ORD001 status updated to shipped successfully (mock response)","timestamp":1757735485904}
 
+Method 5 :
+$ curl -X GET "http://localhost:8084/health" -H "Content-Type: application/json" -v
+
+Note: Unnecessary use of -X or --request,
+Note: GET is already inferred.
+
+- Host localhost:8084 was resolved.
+- IPv6: ::1
+- IPv4: 127.0.0.1
+- Trying [::1]:8084...
+- Connected to localhost (::1) port 8084
+- using HTTP/1.x
+  > GET /health HTTP/1.1
+  > Host: localhost:8084
+  > User-Agent: curl/8.15.0
+  > Accept: _/_
+  > Content-Type: application/json
+- Request completely sent off
+  < HTTP/1.1 200
+  < Content-Type: application/json
+  < Transfer-Encoding: chunked
+  < Date: Sun, 14 Sep 2025 03:47:33 GMT
+  <
+  {"ros":{"status":"UP"},"cms":{"status":"DOWN"},"overall":"DOWN","wms":{"status":"UP"},"timestamp":1757821652999}\* Connection #0 to host localhost left intact

--- a/Swiftlogistics-esb/README.md
+++ b/Swiftlogistics-esb/README.md
@@ -55,5 +55,5 @@ Note: GET is already inferred.
   < Content-Type: application/json
   < Transfer-Encoding: chunked
   < Date: Sun, 14 Sep 2025 03:47:33 GMT
-  <
+  
   {"ros":{"status":"UP"},"cms":{"status":"DOWN"},"overall":"DOWN","wms":{"status":"UP"},"timestamp":1757821652999}\* Connection #0 to host localhost left intact

--- a/Swiftlogistics-esb/pom.xml
+++ b/Swiftlogistics-esb/pom.xml
@@ -121,6 +121,14 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/controller/EsbController.java
+++ b/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/controller/EsbController.java
@@ -177,7 +177,7 @@ public class EsbController {
         }
     }
 
-    // 5. Health check for all systems
+    // 5. Health check for all systems : theesh dev
     @GetMapping("/health")
     public ResponseEntity<Map<String, Object>> healthCheck() {
         logger.info("Performing health check on all systems");

--- a/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/controller/EsbController.java
+++ b/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/controller/EsbController.java
@@ -178,38 +178,38 @@ public class EsbController {
     }
 
     // 5. Health check for all systems
-    // @GetMapping("/health")
-    // public ResponseEntity<Map<String, Object>> healthCheck() {
-    // logger.info("Performing health check on all systems");
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        logger.info("Performing health check on all systems");
 
-    // Map<String, Object> health = new HashMap<>();
+        Map<String, Object> health = new HashMap<>();
 
-    // try {
-    // // Check CMS health
-    // boolean cmsHealthy = cmsService.isHealthy();
-    // health.put("cms", Map.of("status", cmsHealthy ? "UP" : "DOWN"));
+        try {
+            // Check CMS health
+            boolean cmsHealthy = cmsService.isHealthy();
+            health.put("cms", Map.of("status", cmsHealthy ? "UP" : "DOWN"));
 
-    // // Check ROS health
-    // boolean rosHealthy = rosService.isHealthy();
-    // health.put("ros", Map.of("status", rosHealthy ? "UP" : "DOWN"));
+            // Check ROS health
+            boolean rosHealthy = rosService.isHealthy();
+            health.put("ros", Map.of("status", rosHealthy ? "UP" : "DOWN"));
 
-    // // Check WMS health
-    // boolean wmsHealthy = wmsService.isHealthy();
-    // health.put("wms", Map.of("status", wmsHealthy ? "UP" : "DOWN"));
+            // Check WMS health
+            boolean wmsHealthy = wmsService.isHealthy();
+            health.put("wms", Map.of("status", wmsHealthy ? "UP" : "DOWN"));
 
-    // boolean allHealthy = cmsHealthy && rosHealthy && wmsHealthy;
-    // health.put("overall", allHealthy ? "UP" : "DOWN");
-    // health.put("timestamp", System.currentTimeMillis());
+            boolean allHealthy = cmsHealthy && rosHealthy && wmsHealthy;
+            health.put("overall", allHealthy ? "UP" : "DOWN");
+            health.put("timestamp", System.currentTimeMillis());
 
-    // return ResponseEntity.ok(health);
+            return ResponseEntity.ok(health);
 
-    // } catch (Exception e) {
-    // logger.error("Error during health check: ", e);
-    // health.put("overall", "DOWN");
-    // health.put("error", e.getMessage());
-    // return ResponseEntity.internalServerError().body(health);
-    // }
-    // }
+        } catch (Exception e) {
+            logger.error("Error during health check: ", e);
+            health.put("overall", "DOWN");
+            health.put("error", e.getMessage());
+            return ResponseEntity.internalServerError().body(health);
+        }
+    }
 
     // // 6. Route optimization endpoint
     // @PostMapping("/routes/optimize")

--- a/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/service/CmsService.java
+++ b/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/service/CmsService.java
@@ -410,4 +410,45 @@ public class CmsService {
                 system);
         return String.format("%s order %s status updated to %s successfully (mock response)", system, orderId, status);
     }
+
+    // theesh: dev
+    // ...existing code...
+
+    public boolean isHealthy() {
+        try {
+            logger.info("Checking CMS health");
+
+            // Try a simple SOAP request to check if CMS is responding
+            String testRequest = createHealthCheckSoapRequest();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.TEXT_XML);
+            headers.set("SOAPAction", "HealthCheck");
+            headers.set("charset", "utf-8");
+
+            HttpEntity<String> request = new HttpEntity<>(testRequest, headers);
+
+            // Set a short timeout for health check
+            restTemplate.getForObject(CMS_SOAP_URL, String.class);
+
+            logger.info("CMS health check: HEALTHY");
+            return true;
+
+        } catch (Exception e) {
+            logger.warn("CMS health check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String createHealthCheckSoapRequest() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n" +
+                "    <soap:Header/>\n" +
+                "    <soap:Body>\n" +
+                "        <HealthCheck/>\n" +
+                "    </soap:Body>\n" +
+                "</soap:Envelope>";
+    }
+
+    // ...existing code...
 }

--- a/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/service/RosService.java
+++ b/Swiftlogistics-esb/src/main/java/com/swiftlogistics/esb/service/RosService.java
@@ -240,4 +240,42 @@ public class RosService {
                 system);
         return String.format("%s route for order %s updated to %s successfully", system, orderId, status);
     }
+    // theesh:dev
+    // filepath:
+    // d:\Middleware_Architecture_SwiftLogistics\Swiftlogistics-esb\src\main\java\com\swiftlogistics\esb\service\RosService.java
+    // ...existing code...
+
+    public boolean isHealthy() {
+        try {
+            logger.info("Checking ROS health");
+
+            // Try to access the ROS API health endpoint or base URL
+            String[] healthUrls = {
+                    ROS_API_URL + "/health",
+                    ROS_API_URL + "/status",
+                    ROS_API_URL + "/"
+            };
+
+            for (String url : healthUrls) {
+                try {
+                    String response = restTemplate.getForObject(url, String.class);
+                    if (response != null) {
+                        logger.info("ROS health check: HEALTHY");
+                        return true;
+                    }
+                } catch (Exception e) {
+                    logger.debug("Health check failed for URL: {}", url);
+                }
+            }
+
+            logger.warn("ROS health check: UNHEALTHY");
+            return false;
+
+        } catch (Exception e) {
+            logger.warn("ROS health check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    // ...existing code...
 }

--- a/Swiftlogistics-esb/src/test/java/com/swiftlogistics/esb/controller/EsbControllerHealthCheckTest.java
+++ b/Swiftlogistics-esb/src/test/java/com/swiftlogistics/esb/controller/EsbControllerHealthCheckTest.java
@@ -1,0 +1,103 @@
+package com.swiftlogistics.esb.controller;
+
+import com.swiftlogistics.esb.service.CmsService;
+import com.swiftlogistics.esb.service.RosService;
+import com.swiftlogistics.esb.service.WmsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+class EsbControllerHealthCheckTest {
+
+    @Mock
+    private CmsService cmsService;
+
+    @Mock
+    private RosService rosService;
+
+    @Mock
+    private WmsService wmsService;
+
+    @InjectMocks
+    private EsbController esbController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(esbController).build();
+    }
+
+    @Test
+    void healthCheck_AllSystemsHealthy_ShouldReturnOkWithUpStatus() throws Exception {
+        // Arrange
+        when(cmsService.isHealthy()).thenReturn(true);
+        when(rosService.isHealthy()).thenReturn(true);
+        when(wmsService.isHealthy()).thenReturn(true);
+
+        // Act & Assert
+        mockMvc.perform(get("/health")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cms.status").value("UP"))
+                .andExpect(jsonPath("$.ros.status").value("UP"))
+                .andExpect(jsonPath("$.wms.status").value("UP"))
+                .andExpect(jsonPath("$.overall").value("UP"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.error").doesNotExist()); // Fixed: changed andExpected to andExpect
+
+        // Verify service calls
+        verify(cmsService, times(1)).isHealthy();
+        verify(rosService, times(1)).isHealthy();
+        verify(wmsService, times(1)).isHealthy();
+    }
+
+    @Test
+    void healthCheck_SomeSystemsUnhealthy_ShouldReturnOkWithDownOverallStatus() throws Exception {
+        // Arrange
+        when(cmsService.isHealthy()).thenReturn(true);
+        when(rosService.isHealthy()).thenReturn(false);
+        when(wmsService.isHealthy()).thenReturn(true);
+
+        // Act & Assert
+        mockMvc.perform(get("/health")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.cms.status").value("UP"))
+                .andExpected(jsonPath("$.ros.status").value("DOWN"))
+                .andExpect(jsonPath("$.wms.status").value("UP"))
+                .andExpect(jsonPath("$.overall").value("DOWN"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andExpect(jsonPath("$.error").doesNotExist()); // Fixed: changed andExpected to andExpect
+
+        verify(cmsService, times(1)).isHealthy();
+        verify(rosService, times(1)).isHealthy();
+        verify(wmsService, times(1)).isHealthy();
+    }
+
+    @Test
+    void healthCheck_ExceptionThrown_ShouldReturnInternalServerError() throws Exception {
+        // Arrange
+        when(cmsService.isHealthy()).thenThrow(new RuntimeException("CMS connection failed"));
+
+        // Act & Assert
+        mockMvc.perform(get("/health")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.overall").value("DOWN"))
+                .andExpect(jsonPath("$.error").value("CMS connection failed"));
+
+        verify(cmsService, times(1)).isHealthy();
+    }
+}

--- a/Swiftlogistics-esb/src/test/java/com/swiftlogistics/esb/controller/EsbControllerHealthCheckTest.java
+++ b/Swiftlogistics-esb/src/test/java/com/swiftlogistics/esb/controller/EsbControllerHealthCheckTest.java
@@ -75,7 +75,7 @@ class EsbControllerHealthCheckTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.cms.status").value("UP"))
-                .andExpected(jsonPath("$.ros.status").value("DOWN"))
+                .andExpect(jsonPath("$.ros.status").value("DOWN"))
                 .andExpect(jsonPath("$.wms.status").value("UP"))
                 .andExpect(jsonPath("$.overall").value("DOWN"))
                 .andExpect(jsonPath("$.timestamp").exists())


### PR DESCRIPTION
This pull request introduces a new `/health` endpoint to the ESB, providing a comprehensive health check for all integrated systems (CMS, ROS, WMS). It implements health check methods in each service, exposes the endpoint in the controller, documents its usage in the README, and adds unit tests to ensure correct behavior. Additionally, the Maven compiler plugin is configured for Java 17 compatibility.

**Health check endpoint implementation:**

* Added a `/health` endpoint in `EsbController` that checks the health of CMS, ROS, and WMS services, returning an aggregated status and timestamp. Handles exceptions gracefully by returning an error and setting the overall status to "DOWN".
* Implemented `isHealthy()` methods in `CmsService`, `RosService`, and `WmsService` to perform real connectivity checks to each system (SOAP, REST, TCP respectively). [[1]](diffhunk://#diff-a795bf170e2b151ec59f4557e265bbec38536a8565833c189764a1c7d03a6a99R413-R453) [[2]](diffhunk://#diff-ff967d5035b39bee9f1be9582ce05b5e091b38a526523fb69a25929c77a5c2ecR243-R280) [[3]](diffhunk://#diff-f9d734034013f2741d4c7d7584d8cfc4761247cb352c1752568738910e8ae0ffR317-R367)

**Testing and documentation:**

* Added `EsbControllerHealthCheckTest` to verify the `/health` endpoint's behavior under various scenarios, including all systems healthy, partial failures, and exception handling.
* Updated `README.md` to document the new `/health` endpoint, including example usage and sample output. [[1]](diffhunk://#diff-69b83164aeed83621d2efd609d3cfffbc800724ddc765f46d6371b8738e874f5R27-R59) [[2]](diffhunk://#diff-69b83164aeed83621d2efd609d3cfffbc800724ddc765f46d6371b8738e874f5R2-R4)

**Build configuration:**

* Configured the Maven compiler plugin in `pom.xml` to use Java 17 for source and target compatibility.